### PR TITLE
Feature/explicit instance registrations

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+branch = True
+source=punq
+
+[report]
+show_missing = True
+

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
-* 0.0.1
-	* Basic resolution and registration works
-	* Punq is almost certainly slow as a dog, non thread-safe, and prone to weird behaviour in the edge cases.
+## [0.1.0] 2019-02-11
+### Breaking Changes
+    - Added explicit `instance` kwarg to `register` which replaces the previous behaviour where
+      `container.register(Service, someInstance)` would register a concrete instance.
+      This fixes https://github.com/bobthemighty/punq/issues/6
+
+
+## 0.0.1
+	- Basic resolution and registration works
+	- Punq is almost certainly slow as a dog, non thread-safe, and prone to weird behaviour in the edge cases.

--- a/punq/__init__.py
+++ b/punq/__init__.py
@@ -4,7 +4,7 @@ from collections import defaultdict, namedtuple
 
 from pkg_resources import DistributionNotFound, get_distribution
 
-if sys.version_info >= (3, 7, 0): 
+if sys.version_info >= (3, 7, 0):
     from .py_37 import is_generic_list
 else:
     from .py_36 import is_generic_list
@@ -24,8 +24,7 @@ class InvalidRegistrationException(Exception):
     pass
 
 
-Registration = namedtuple("Registration",
-                          ["service", "builder", "needs", "args"])
+Registration = namedtuple("Registration", ["service", "builder", "needs", "args"])
 
 
 class Registry:
@@ -58,8 +57,8 @@ class Registry:
                 >>> Sending message via smtp
         """
         self.__registrations[service].append(
-            Registration(service, impl, self._get_needs_for_ctor(impl),
-                         resolve_args))
+            Registration(service, impl, self._get_needs_for_ctor(impl), resolve_args)
+        )
 
     def register_service_and_instance(self, service, instance):
         """Register a singleton instance to implement a service.
@@ -80,7 +79,8 @@ class Registry:
             ...     DataAccessLayer,
             ...     SqlAlchemyDataAccessLayer(create_engine(db_uri)))"""
         self.__registrations[service].append(
-            Registration(service, lambda: instance, {}, {}))
+            Registration(service, lambda: instance, {}, {})
+        )
 
     def register_concrete_service(self, service):
         """ Register a service as its own implementation.
@@ -99,18 +99,18 @@ class Registry:
         if not type(service) is type:
             raise InvalidRegistrationException(
                 "The service %s can't be registered as its own implementation"
-                % (repr(service)))
+                % (repr(service))
+            )
         self.__registrations[service].append(
-            Registration(service, service, self._get_needs_for_ctor(service),
-                         {}))
+            Registration(service, service, self._get_needs_for_ctor(service), {})
+        )
 
     def build_context(self, key, existing=None):
         if existing is None:
             return ResolutionContext(key, list(self.__getitem__(key)))
 
         if key not in existing.targets:
-            existing.targets[key] = ResolutionTarget(
-                key, list(self.__getitem__(key)))
+            existing.targets[key] = ResolutionTarget(key, list(self.__getitem__(key)))
 
         return existing
 
@@ -220,7 +220,8 @@ class Container:
 
         if registration is None:
             raise MissingDependencyException(
-                "Failed to resolve implementation for " + str(service_key))
+                "Failed to resolve implementation for " + str(service_key)
+            )
 
         if service_key in registration.needs.values():
             self._resolve_impl(service_key, kwargs, context)

--- a/punq/__init__.py
+++ b/punq/__init__.py
@@ -26,7 +26,12 @@ class InvalidRegistrationException(Exception):
 
 Registration = namedtuple("Registration", ["service", "builder", "needs", "args"])
 
-sentinel = object()
+
+class Empty:
+    pass
+
+
+empty = Empty()
 
 
 class Registry:
@@ -116,12 +121,12 @@ class Registry:
 
         return existing
 
-    def register(self, service, factory=sentinel, instance=sentinel, **kwargs):
+    def register(self, service, factory=empty, instance=empty, **kwargs):
         resolve_args = kwargs or {}
 
-        if instance is not sentinel:
+        if instance is not empty:
             self.register_service_and_instance(service, instance)
-        elif factory is sentinel:
+        elif factory is empty:
             self.register_concrete_service(service)
         elif callable(factory):
             self.register_service_and_impl(service, factory, resolve_args)
@@ -177,7 +182,7 @@ class Container:
     def __init__(self):
         self.registrations = Registry()
 
-    def register(self, service, factory=sentinel, instance=sentinel, **kwargs):
+    def register(self, service, factory=empty, instance=empty, **kwargs):
         self.registrations.register(service, factory, instance, **kwargs)
 
         return self

--- a/punq/__init__.py
+++ b/punq/__init__.py
@@ -114,18 +114,18 @@ class Registry:
 
         return existing
 
-    def register(self, _service, _factory=None, _instance=None, **kwargs):
+    def register(self, service, factory=None, instance=None, **kwargs):
         resolve_args = kwargs or {}
 
-        if _instance is not None:
-            self.register_service_and_instance(_service, _instance)
-        elif _factory is None:
-            self.register_concrete_service(_service)
-        elif callable(_factory):
-            self.register_service_and_impl(_service, _factory, resolve_args)
+        if instance is not None:
+            self.register_service_and_instance(service, instance)
+        elif factory is None:
+            self.register_concrete_service(service)
+        elif callable(factory):
+            self.register_service_and_impl(service, factory, resolve_args)
         else:
             raise InvalidRegistrationException(
-                f"Expected a callable factory for the service {_service} but received {_factory}"
+                f"Expected a callable factory for the service {service} but received {factory}"
             )
 
     def __getitem__(self, service):
@@ -175,8 +175,8 @@ class Container:
     def __init__(self):
         self.registrations = Registry()
 
-    def register(self, service, _factory=None, **kwargs):
-        self.registrations.register(service, _factory, **kwargs)
+    def register(self, service, factory=None, instance=None, **kwargs):
+        self.registrations.register(service, factory, instance, **kwargs)
 
         return self
 

--- a/punq/__init__.py
+++ b/punq/__init__.py
@@ -1,17 +1,17 @@
 import sys
 import typing
 from collections import defaultdict, namedtuple
+
 from pkg_resources import DistributionNotFound, get_distribution
 
-if sys.version_info >= (3, 7, 0):
+if sys.version_info >= (3, 7, 0): 
     from .py_37 import is_generic_list
 else:
     from .py_36 import is_generic_list
 
-
-try:
+try:  # pragma no cover
     __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+except DistributionNotFound:  # pragma no cover
     # package is not installed
     pass
 
@@ -24,7 +24,8 @@ class InvalidRegistrationException(Exception):
     pass
 
 
-Registration = namedtuple("Registration", ["service", "builder", "needs", "args"])
+Registration = namedtuple("Registration",
+                          ["service", "builder", "needs", "args"])
 
 
 class Registry:
@@ -57,8 +58,8 @@ class Registry:
                 >>> Sending message via smtp
         """
         self.__registrations[service].append(
-            Registration(service, impl, self._get_needs_for_ctor(impl), resolve_args)
-        )
+            Registration(service, impl, self._get_needs_for_ctor(impl),
+                         resolve_args))
 
     def register_service_and_instance(self, service, instance):
         """Register a singleton instance to implement a service.
@@ -79,8 +80,7 @@ class Registry:
             ...     DataAccessLayer,
             ...     SqlAlchemyDataAccessLayer(create_engine(db_uri)))"""
         self.__registrations[service].append(
-            Registration(service, lambda: instance, {}, {})
-        )
+            Registration(service, lambda: instance, {}, {}))
 
     def register_concrete_service(self, service):
         """ Register a service as its own implementation.
@@ -99,37 +99,37 @@ class Registry:
         if not type(service) is type:
             raise InvalidRegistrationException(
                 "The service %s can't be registered as its own implementation"
-                % (repr(service))
-            )
+                % (repr(service)))
         self.__registrations[service].append(
-            Registration(service, service, self._get_needs_for_ctor(service), {})
-        )
+            Registration(service, service, self._get_needs_for_ctor(service),
+                         {}))
 
     def build_context(self, key, existing=None):
         if existing is None:
             return ResolutionContext(key, list(self.__getitem__(key)))
 
         if key not in existing.targets:
-            existing.targets[key] = ResolutionTarget(key, list(self.__getitem__(key)))
+            existing.targets[key] = ResolutionTarget(
+                key, list(self.__getitem__(key)))
 
         return existing
 
-    def register(self, service, _factory=None, **kwargs):
+    def register(self, _service, _factory=None, _instance=None, **kwargs):
         resolve_args = kwargs or {}
 
-        if _factory is None:
-            self.register_concrete_service(service)
+        if _instance is not None:
+            self.register_service_and_instance(_service, _instance)
+        elif _factory is None:
+            self.register_concrete_service(_service)
         elif callable(_factory):
-            self.register_service_and_impl(service, _factory, resolve_args)
+            self.register_service_and_impl(_service, _factory, resolve_args)
         else:
-            self.register_service_and_instance(service, _factory)
+            raise InvalidRegistrationException(
+                f"Expected a callable factory for the service {_service} but received {_factory}"
+            )
 
     def __getitem__(self, service):
         return self.__registrations[service]
-
-    @property
-    def registrations(self):
-        return typing.MappingProxyType(self.__registrations)
 
 
 class ResolutionTarget:
@@ -177,6 +177,7 @@ class Container:
 
     def register(self, service, _factory=None, **kwargs):
         self.registrations.register(service, _factory, **kwargs)
+
         return self
 
     def resolve_all(self, service, **kwargs):
@@ -219,8 +220,7 @@ class Container:
 
         if registration is None:
             raise MissingDependencyException(
-                "Failed to resolve implementation for " + str(service_key)
-            )
+                "Failed to resolve implementation for " + str(service_key))
 
         if service_key in registration.needs.values():
             self._resolve_impl(service_key, kwargs, context)

--- a/punq/__init__.py
+++ b/punq/__init__.py
@@ -26,6 +26,8 @@ class InvalidRegistrationException(Exception):
 
 Registration = namedtuple("Registration", ["service", "builder", "needs", "args"])
 
+sentinel = object()
+
 
 class Registry:
     def __init__(self):
@@ -114,12 +116,12 @@ class Registry:
 
         return existing
 
-    def register(self, service, factory=None, instance=None, **kwargs):
+    def register(self, service, factory=sentinel, instance=sentinel, **kwargs):
         resolve_args = kwargs or {}
 
-        if instance is not None:
+        if instance is not sentinel:
             self.register_service_and_instance(service, instance)
-        elif factory is None:
+        elif factory is sentinel:
             self.register_concrete_service(service)
         elif callable(factory):
             self.register_service_and_impl(service, factory, resolve_args)
@@ -175,7 +177,7 @@ class Container:
     def __init__(self):
         self.registrations = Registry()
 
-    def register(self, service, factory=None, instance=None, **kwargs):
+    def register(self, service, factory=sentinel, instance=sentinel, **kwargs):
         self.registrations.register(service, factory, instance, **kwargs)
 
         return self

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,4 +1,4 @@
-from typing import Callable, List, NewType
+from typing import Callable
 
 
 class MessageWriter:
@@ -25,7 +25,7 @@ class TmpFileMessageWriter(MessageWriter):
             f.write(msg)
 
 
-ConnectionStringFactory = NewType("ConnectionStringFactory", Callable[[], str])
+ConnectionStringFactory = Callable[[], str]
 
 
 class FancyDbMessageWriter(MessageWriter):

--- a/tests/test_instance_creation.py
+++ b/tests/test_instance_creation.py
@@ -2,11 +2,15 @@ from typing import List
 
 import pytest
 from expects import be, be_a, equal, expect, have_len
-from punq import (Container, InvalidRegistrationException,
-                  MissingDependencyException)
-from tests.test_dependencies import (FancyDbMessageWriter, HelloWorldSpeaker,
-                                     MessageSpeaker, MessageWriter,
-                                     StdoutMessageWriter, TmpFileMessageWriter)
+from punq import Container, InvalidRegistrationException, MissingDependencyException
+from tests.test_dependencies import (
+    FancyDbMessageWriter,
+    HelloWorldSpeaker,
+    MessageSpeaker,
+    MessageWriter,
+    StdoutMessageWriter,
+    TmpFileMessageWriter,
+)
 
 
 def test_can_create_instance_with_no_dependencies():
@@ -38,8 +42,7 @@ def test_can_register_a_concrete_type():
     container = Container()
     container.register(StdoutMessageWriter)
 
-    expect(container.resolve(StdoutMessageWriter)).to(
-        be_a(StdoutMessageWriter))
+    expect(container.resolve(StdoutMessageWriter)).to(be_a(StdoutMessageWriter))
 
 
 def test_can_register_with_a_custom_factory():
@@ -84,7 +87,6 @@ def test_registering_an_instance_as_factory_is_exception():
         container.register(MessageWriter, writer)
 
 
-
 def test_registering_a_callable_as_concrete_is_exception():
     """
     Likewise, if we register an arbitrary callable, there's
@@ -100,8 +102,7 @@ def test_registering_a_callable_as_concrete_is_exception():
 
 def test_can_provide_arguments_to_registrations():
     container = Container()
-    container.register(
-        MessageWriter, FancyDbMessageWriter, cstr=lambda: "Hello world")
+    container.register(MessageWriter, FancyDbMessageWriter, cstr=lambda: "Hello world")
 
     writer = container.resolve(MessageWriter)
 

--- a/tests/test_instance_creation.py
+++ b/tests/test_instance_creation.py
@@ -59,7 +59,7 @@ def test_can_register_with_a_custom_factory():
 def test_can_register_an_instance():
     container = Container()
     writer = TmpFileMessageWriter("my-file")
-    container.register(MessageWriter, _instance=writer)
+    container.register(MessageWriter, instance=writer)
     expect(container.resolve(MessageWriter)).to(equal(writer))
 
 

--- a/tests/test_list_resolution.py
+++ b/tests/test_list_resolution.py
@@ -2,8 +2,12 @@ from typing import List
 
 from expects import expect, have_len
 from punq import Container
-from tests.test_dependencies import (MessageSpeaker, MessageWriter,
-                                     StdoutMessageWriter, TmpFileMessageWriter)
+from tests.test_dependencies import (
+    MessageSpeaker,
+    MessageWriter,
+    StdoutMessageWriter,
+    TmpFileMessageWriter,
+)
 
 
 def test_can_resolve_a_list_of_dependencies():

--- a/tests/test_list_resolution.py
+++ b/tests/test_list_resolution.py
@@ -1,0 +1,29 @@
+from typing import List
+
+from expects import expect, have_len
+from punq import Container
+from tests.test_dependencies import (MessageSpeaker, MessageWriter,
+                                     StdoutMessageWriter, TmpFileMessageWriter)
+
+
+def test_can_resolve_a_list_of_dependencies():
+    """
+    In this test we create a composite MessageSpeaker that depends on a list of
+    MessageWriters.
+
+    When we resolve the speaker, it should be provided with a list of all the
+    registered writers.
+    """
+
+    class BroadcastSpeaker:
+        def __init__(self, writers: List[MessageWriter]) -> None:
+            self.writers = writers
+
+    container = Container()
+    container.register(MessageWriter, StdoutMessageWriter)
+    container.register(MessageWriter, TmpFileMessageWriter, path="my-file")
+    container.register(MessageSpeaker, BroadcastSpeaker)
+
+    instance = container.resolve(MessageSpeaker)
+
+    expect(instance.writers).to(have_len(2))


### PR DESCRIPTION
This PR changes the register method so that:

* Instances must now be explicitly registered with `container.register(service, instance=some_obj)`
* It is now an error to pass a non-callable instance as a factory, eg . `container.register(int, 3)` will now fail with invalid registration.
* The `_factory` kwarg is now named `factory` on the grounds that while name collisions for constructor params *might* be a confusing edge case, needing to pass `_instance=foo` is *definitely* confusing in a common case. 

Also excluded some `setuptools_scm` warts from coverage so we should be at 100%.