### PR TITLE
Bugfix/forward references are unresolvable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## [0.2.0] 2019-02-12
+### Fixes https://github.com/bobthemighty/punq/issues/9
+    - Added handling for typing.ForwardRef
+
 ## [0.1.0] 2019-02-11
 ### Breaking Changes
     - Added explicit `instance` kwarg to `register` which replaces the previous behaviour where

--- a/Pipfile
+++ b/Pipfile
@@ -17,6 +17,7 @@ codecov = "*"
 [packages]
 setuptools-scm = "*"
 punq = {editable = true,path = "."}
+attrs = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "21eac7562dfabb0c616f19c03735238f160189cb64d2098f72e2231dfc45a2df"
+            "sha256": "d94d66f8e81f7b4d6f74c928225e55e272d8706b17cdbb8fcc2bf7f1c9a4ecdd"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,14 @@
         ]
     },
     "default": {
+        "attrs": {
+            "hashes": [
+                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
+                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
+            ],
+            "index": "pypi",
+            "version": "==18.2.0"
+        },
         "punq": {
             "editable": true,
             "path": "."
@@ -56,6 +64,7 @@
                 "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
                 "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
             ],
+            "index": "pypi",
             "version": "==18.2.0"
         },
         "babel": {
@@ -223,11 +232,10 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:38a936c0a6d98a38bcc2d03fdaaedaba9f412879461dd2ceff8d37564d6522e4",
-                "sha256:c0a5785b1109a6bd7fac76d6837fd1feca158e54e521ccd2ae8bfe393cc9d4fc",
-                "sha256:fe7a7cae1ccb57d33952113ff4fa1bc5f879963600ed74918f1236e212ee50b9"
+                "sha256:0125e8f60e9e031347105eb1682cef932f5e97d7b9a1a28d9bf00c22a5daef40",
+                "sha256:590044e3942351a1bdb1de960b739ff4ce277960f2425ad4509446dbace8d9d1"
             ],
-            "version": "==5.0.0"
+            "version": "==6.0.0"
         },
         "packaging": {
             "hashes": [

--- a/punq/__init__.py
+++ b/punq/__init__.py
@@ -82,6 +82,7 @@ class InvalidForwardReferenceException(Exception):
         >>> container.resolve(Client)
         Client(dep=<__main__.AlternativeDependency object at 0x7f345c7f80f0>)
     """
+
     pass
 
 
@@ -189,7 +190,6 @@ class Registry:
             self._localns[service.__name__] = service
         else:
             self._localns[service] = service
-
 
     def register(self, service, factory=empty, instance=empty, **kwargs):
         resolve_args = kwargs or {}

--- a/punq/__init__.py
+++ b/punq/__init__.py
@@ -24,6 +24,67 @@ class InvalidRegistrationException(Exception):
     pass
 
 
+class InvalidForwardReferenceException(Exception):
+    """
+    Raised when a registered service has a forward reference that can't be
+    resolved.
+
+    Examples:
+        In this example, we register a service with a string as a type annotation.
+        When we try to inspect the constructor for the service we fail with an
+        InvalidForwardReferenceException
+
+        >>> from dataclasses import dataclass
+        >>> @dataclass
+        ... class Client:
+        ...     dep: 'Dependency'
+        >>> container = Container()
+        >>> container.register(Client)
+        Traceback (most recent call last):
+        File "<stdin>", line 1, in <module>
+        File "__init__.py", line 195, in register
+          self.registrations.register(service, factory, instance, **kwargs)
+        File "__init__.py", line 139, in register
+          self.register_concrete_service(service)
+        File "__init__.py", line 121, in register_concrete_service
+          Registration(service, service, self._get_needs_for_ctor(service), {})
+        File "__init__.py", line 53, in _get_needs_for_ctor
+          raise InvalidForwardReferenceException(str(e))
+      punq.InvalidForwardReferenceException: name 'Dependency' is not defined
+
+
+        This error can be resolved by first registering a type with the name
+        'Dependency' in the container.
+
+        >>> class Dependency:
+        ...     pass
+        ...
+        >>> container.register(Dependency)
+        <punq.Container object at 0x7f345cb6cac8>
+        >>> container.register(Client)
+        >>> container.register(Client)
+        <punq.Container object at 0x7f345cb6cac8>
+        >>> container.resolve(Client)
+        Client(dep=<__main__.Dependency object at 0x7f345c7f80f0>)
+
+
+        Alternatively, we can register a type using the literal key 'Dependency'.
+
+        >>> class AlternativeDependency:
+        ...     pass
+        ...
+        >>> container = Container()
+        <punq.Container object at 0x7fbd3a69ef60>
+        >>> container.register('Dependency', AlternativeDependency)
+        <punq.Container object at 0x7fbd3a69ef60>
+        >>> container.register(Client)
+        <punq.Container object at 0x7fbd3a69ef60>
+        >>> container.resolve(Client)
+        Client(dep=<__main__.AlternativeDependency object at 0x7f345c7f80f0>)
+    """
+    pass
+
+
 Registration = namedtuple("Registration", ["service", "builder", "needs", "args"])
 
 
@@ -37,11 +98,13 @@ empty = Empty()
 class Registry:
     def __init__(self):
         self.__registrations = defaultdict(list)
+        self._localns = dict()
 
     def _get_needs_for_ctor(self, cls):
-        sig = typing.get_type_hints(cls.__init__)
-
-        return sig
+        try:
+            return typing.get_type_hints(cls.__init__, None, self._localns)
+        except NameError as e:
+            raise InvalidForwardReferenceException(str(e))
 
     def register_service_and_impl(self, service, impl, resolve_args):
         """Registers a concrete implementation of an abstract service.
@@ -121,6 +184,13 @@ class Registry:
 
         return existing
 
+    def _update_localns(self, service):
+        if type(service) == type:
+            self._localns[service.__name__] = service
+        else:
+            self._localns[service] = service
+
+
     def register(self, service, factory=empty, instance=empty, **kwargs):
         resolve_args = kwargs or {}
 
@@ -134,6 +204,9 @@ class Registry:
             raise InvalidRegistrationException(
                 f"Expected a callable factory for the service {service} but received {factory}"
             )
+        self._update_localns(service)
+        if isinstance(service, str):
+            self.register(typing.ForwardRef(service), factory, instance, **kwargs)
 
     def __getitem__(self, service):
         return self.__registrations[service]

--- a/punq/__init__.py
+++ b/punq/__init__.py
@@ -5,9 +5,9 @@ from collections import defaultdict, namedtuple
 from pkg_resources import DistributionNotFound, get_distribution
 
 if sys.version_info >= (3, 7, 0):
-    from .py_37 import is_generic_list
+    from .py_37 import is_generic_list, ensure_forward_ref
 else:
-    from .py_36 import is_generic_list
+    from .py_36 import is_generic_list, ensure_forward_ref
 
 try:  # pragma no cover
     __version__ = get_distribution(__name__).version
@@ -205,8 +205,7 @@ class Registry:
                 f"Expected a callable factory for the service {service} but received {factory}"
             )
         self._update_localns(service)
-        if isinstance(service, str):
-            self.register(typing.ForwardRef(service), factory, instance, **kwargs)
+        ensure_forward_ref(self, service, factory, instance, **kwargs)
 
     def __getitem__(self, service):
         return self.__registrations[service]

--- a/punq/py_36.py
+++ b/punq/py_36.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, _ForwardRef
 
 
 def is_generic_list(service):
@@ -6,3 +6,8 @@ def is_generic_list(service):
         return service.__origin__ == List
     except AttributeError:
         return False
+
+
+def ensure_forward_ref(self, service, factory, instance, **kwargs):
+    if isinstance(service, str):
+        self.register(_ForwardRef(service), factory, instance, **kwargs)

--- a/punq/py_37.py
+++ b/punq/py_37.py
@@ -1,5 +1,13 @@
+from typing import ForwardRef
+
+
 def is_generic_list(service):
     try:
         return service.__origin__ == list
     except AttributeError:
         return False
+
+
+def ensure_forward_ref(self, service, factory, instance, **kwargs):
+    if isinstance(service, str):
+        self.register(ForwardRef(service), factory, instance, **kwargs)

--- a/tests/test_instance_creation.py
+++ b/tests/test_instance_creation.py
@@ -134,3 +134,9 @@ def test_resolve_all_returns_all_registrations_in_order():
     [first, second] = container.resolve_all(MessageWriter)
     expect(first).to(be_a(StdoutMessageWriter))
     expect(second).to(be_a(TmpFileMessageWriter))
+
+
+def test_can_use_a_string_key():
+    container = Container()
+    container.register("foo", instance=1)
+    assert container.resolve("foo") == 1

--- a/tests/test_string_annotations.py
+++ b/tests/test_string_annotations.py
@@ -7,19 +7,20 @@ The fix is to provide a dict of the previously registered services to the
 get_type_hints function, so that we can resolve forward references to any
 previously registered service.
 """
-from dataclasses import dataclass
+
+import attr
 
 import punq
 import pytest
 
 
-@dataclass
-class Client(object):
+@attr.s(auto_attribs=True)
+class Client:
     dep: "Dependency"
 
 
-@dataclass
-class Dependency(object):
+@attr.s(auto_attribs=True)
+class Dependency:
     val = 1
 
 

--- a/tests/test_string_annotations.py
+++ b/tests/test_string_annotations.py
@@ -1,0 +1,52 @@
+"""
+As per github.com/bobthemighty/punq/issues/9 if we register a type in the
+container that uses a forward declaration for a dependency, we hit a bug in
+the `typing` module that causes a name error.
+
+The fix is to provide a dict of the previously registered services to the
+get_type_hints function, so that we can resolve forward references to any
+previously registered service.
+"""
+from dataclasses import dataclass
+
+import punq
+import pytest
+
+
+@dataclass
+class Client(object):
+    dep: "Dependency"
+
+
+@dataclass
+class Dependency(object):
+    val = 1
+
+
+class DataAccessLayer:
+    val = 2
+
+
+def test_can_resolve_objects_with_forward_references():
+    container = punq.Container()
+    container.register(Dependency)
+    container.register(Client)
+
+    instance = container.resolve(Client)
+    assert instance.dep.val == 1
+
+
+def test_forward_references_must_be_registered_before_their_clients():
+    container = punq.Container()
+
+    with pytest.raises(punq.InvalidForwardReferenceException):
+        container.register(Client)
+
+
+def test_forward_references_can_be_registered_as_strings():
+    container = punq.Container()
+    container.register("Dependency", DataAccessLayer)
+    container.register(Client)
+
+    instance = container.resolve(Client)
+    assert instance.dep.val == 2


### PR DESCRIPTION
Fixes #9 

Added special handling for ForwardRef:

1. When registering a new service, we use the existing set of registrations as the `localns` argument to get_type_hints, which provides a workaround for the NameError
2. After registering a new service, if the service key is a string, we also add a ForwardRef(service) to the registrations so that users can have arbitrary string keys in their types. 