### PR TITLE
Fix 'resolve'-time argument binding

### DIFF
--- a/punq/__init__.py
+++ b/punq/__init__.py
@@ -357,7 +357,8 @@ class Container:
         args = {
             k: self._resolve_impl(v, resolution_args, context)
             for k, v in registration.needs.items()
-            if k != "return" and k not in registration.args
+            if k != "return" and k not in registration.args \
+                and k not in resolution_args
         }
         args.update(registration.args)
         args.update(resolution_args or {})

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -21,7 +21,7 @@ class TmpFileMessageWriter(MessageWriter):
         self.path = path
 
     def write(self, msg: str) -> None:
-        with open(self.path) as f:
+        with open(self.path, 'w') as f:
             f.write(msg)
 
 


### PR DESCRIPTION
`punq` tries to create an instance of every argument which was not specified at the registration time. It doesn't always make sense, especially with arguments which take more complex initialization parameters than a string.

 See the supplied test case for a situation when it can lead to problems.