### PR TITLE
Do not create dependencies that are passed as resolution_args

### DIFF
--- a/punq/__init__.py
+++ b/punq/__init__.py
@@ -392,8 +392,7 @@ class Container:
         args = {
             k: self._resolve_impl(v, resolution_args, context)
             for k, v in registration.needs.items()
-            if k != "return" and k not in registration.args \
-                and k not in resolution_args
+            if k != "return" and k not in registration.args and k not in resolution_args
         }
         args.update(registration.args)
         args.update(resolution_args or {})

--- a/punq/__init__.py
+++ b/punq/__init__.py
@@ -392,7 +392,8 @@ class Container:
         args = {
             k: self._resolve_impl(v, resolution_args, context)
             for k, v in registration.needs.items()
-            if k != "return" and k not in registration.args
+            if k != "return" and k not in registration.args \
+                and k not in resolution_args
         }
         args.update(registration.args)
         args.update(resolution_args or {})

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -21,7 +21,7 @@ class TmpFileMessageWriter(MessageWriter):
         self.path = path
 
     def write(self, msg: str) -> None:
-        with open(self.path) as f:
+        with open(self.path, 'w') as f:
             f.write(msg)
 
 

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -21,7 +21,7 @@ class TmpFileMessageWriter(MessageWriter):
         self.path = path
 
     def write(self, msg: str) -> None:
-        with open(self.path, 'w') as f:
+        with open(self.path, "w") as f:
             f.write(msg)
 
 

--- a/tests/test_instance_creation.py
+++ b/tests/test_instance_creation.py
@@ -134,14 +134,14 @@ def test_can_provide_typed_arguments_to_resolve():
     speaker.speak()
 
     tmpfile.seek(0)
-    expect(tmpfile.read().decode()).to(equal('Hello World'))
+    expect(tmpfile.read().decode()).to(equal("Hello World"))
 
 
 def test_resolve_returns_the_latest_registration_for_a_service():
     container = Container()
     container.register(MessageWriter, StdoutMessageWriter)
 
-    container.register(MessageWriter, TmpFileMessageWriter, path='my-file')
+    container.register(MessageWriter, TmpFileMessageWriter, path="my-file")
 
     expect(container.resolve(MessageWriter)).to(be_a(TmpFileMessageWriter))
 


### PR DESCRIPTION
Fixes an issue where punq will attempt to create a constructor argument even when it's provided to the resolve call.