### PR TITLE
fix for resolve with arguments and complex dependencies

### DIFF
--- a/punq/__init__.py
+++ b/punq/__init__.py
@@ -1,4 +1,5 @@
 import typing
+import inspect
 from collections import defaultdict, namedtuple
 
 from pkg_resources import DistributionNotFound, get_distribution
@@ -395,7 +396,12 @@ class Container:
             if k != "return" and k not in registration.args and k not in resolution_args
         }
         args.update(registration.args)
-        args.update(resolution_args or {})
+
+        target_args = inspect.getfullargspec(registration.builder).args
+        if "self" in target_args: target_args.remove("self")
+        condensed_resolution_args = { key:resolution_args[key] for key in resolution_args if key in target_args }
+        args.update(condensed_resolution_args or {})
+
         result = registration.builder(**args)
         context[registration.service] = result
 

--- a/punq/__init__.py
+++ b/punq/__init__.py
@@ -398,8 +398,11 @@ class Container:
         args.update(registration.args)
 
         target_args = inspect.getfullargspec(registration.builder).args
-        if "self" in target_args: target_args.remove("self")
-        condensed_resolution_args = { key:resolution_args[key] for key in resolution_args if key in target_args }
+        if "self" in target_args:
+            target_args.remove("self")
+        condensed_resolution_args = {
+            key: resolution_args[key] for key in resolution_args if key in target_args
+        }
         args.update(condensed_resolution_args or {})
 
         result = registration.builder(**args)

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -35,6 +35,13 @@ class FancyDbMessageWriter(MessageWriter):
     def write(self, msg):
         pass
 
+class WrappingMessageWriter(MessageWriter):
+    def __init__(self, wrapped: StdoutMessageWriter, context: str) -> None:
+        self.wrapped = wrapped
+        self.context = context
+
+    def write(self, msg):
+        self.wrapped.write(self.context + ": " + msg)
 
 class HelloWorldSpeaker(MessageSpeaker):
     def __init__(self, writer: MessageWriter) -> None:

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -35,6 +35,7 @@ class FancyDbMessageWriter(MessageWriter):
     def write(self, msg):
         pass
 
+
 class WrappingMessageWriter(MessageWriter):
     def __init__(self, wrapped: StdoutMessageWriter, context: str) -> None:
         self.wrapped = wrapped
@@ -42,6 +43,7 @@ class WrappingMessageWriter(MessageWriter):
 
     def write(self, msg):
         self.wrapped.write(self.context + ": " + msg)
+
 
 class HelloWorldSpeaker(MessageSpeaker):
     def __init__(self, writer: MessageWriter) -> None:

--- a/tests/test_instance_creation.py
+++ b/tests/test_instance_creation.py
@@ -12,6 +12,7 @@ from tests.test_dependencies import (
     MessageWriter,
     StdoutMessageWriter,
     TmpFileMessageWriter,
+    WrappingMessageWriter,
 )
 
 
@@ -119,6 +120,13 @@ def test_can_provide_arguments_to_resolve():
     instance = container.resolve(MessageWriter, path="foo")
     expect(instance.path).to(equal("foo"))
 
+def test_can_provide_arguments_to_resolve_having_dependencies():
+    container = Container()
+    container.register(StdoutMessageWriter, StdoutMessageWriter)
+    container.register(MessageWriter, WrappingMessageWriter)
+
+    instance = container.resolve(MessageWriter, context="bar")
+    expect(instance.context).to(equal("bar"))
 
 def test_can_provide_typed_arguments_to_resolve():
     container = Container()

--- a/tests/test_instance_creation.py
+++ b/tests/test_instance_creation.py
@@ -120,6 +120,7 @@ def test_can_provide_arguments_to_resolve():
     instance = container.resolve(MessageWriter, path="foo")
     expect(instance.path).to(equal("foo"))
 
+
 def test_can_provide_arguments_to_resolve_having_dependencies():
     container = Container()
     container.register(StdoutMessageWriter, StdoutMessageWriter)
@@ -127,6 +128,7 @@ def test_can_provide_arguments_to_resolve_having_dependencies():
 
     instance = container.resolve(MessageWriter, context="bar")
     expect(instance.context).to(equal("bar"))
+
 
 def test_can_provide_typed_arguments_to_resolve():
     container = Container()


### PR DESCRIPTION
Hi there,
first thanks for this framework, makes python life a lot easier for us.

When resolving dependencies with arguments, those arguments are injected into every dependency, failing on those which don't need them. Consider following example:
Dependency A needs dependency B via an argument and dependency C, which has no further dependencies. Injection will fail since punq tries to inject dependency B into dependency C as well.

I've changed the code so that arguments dependencies get compared with target dependencies and only those which are needed get injected. However, this is a breaking change from the current behavior.

Cheers