### PR TITLE
Support both singleton and prototype scopes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# pytest
+.pytest_cache/

--- a/tests/test_instance_creation.py
+++ b/tests/test_instance_creation.py
@@ -66,6 +66,17 @@ def test_can_register_an_instance():
     expect(container.resolve(MessageWriter)).to(equal(writer))
 
 
+def test_resolves_instances_with_default_scope():
+    """
+    No scope specified should work the way prototype scope works
+    """
+    container = Container()
+    container.register(MessageWriter, StdoutMessageWriter)
+
+    mw1 = container.resolve(MessageWriter)
+    mw2 = container.resolve(MessageWriter)
+    expect(mw1).not_to(equal(mw2))
+
 def test_resolves_instances_with_singleton_scope():
     container = Container()
     container.register(MessageWriter, StdoutMessageWriter, scope=Scope.singleton)

--- a/tests/test_instance_creation.py
+++ b/tests/test_instance_creation.py
@@ -77,6 +77,7 @@ def test_resolves_instances_with_default_scope():
     mw2 = container.resolve(MessageWriter)
     expect(mw1).not_to(equal(mw2))
 
+
 def test_resolves_instances_with_singleton_scope():
     container = Container()
     container.register(MessageWriter, StdoutMessageWriter, scope=Scope.singleton)
@@ -93,6 +94,16 @@ def test_resolves_instances_with_prototype_scope():
     mw1 = container.resolve(MessageWriter)
     mw2 = container.resolve(MessageWriter)
     expect(mw1).not_to(equal(mw2))
+
+
+def test_resolves_instances_with_default_singleton():
+    container = Container(default_scope=Scope.singleton)
+    container.register(MessageWriter, StdoutMessageWriter)
+
+    mw1 = container.resolve(MessageWriter)
+    mw2 = container.resolve(MessageWriter)
+    expect(mw1).to(equal(mw2))
+
 
 def test_registering_an_instance_with_prototype_scope_is_exception():
     container = Container()

--- a/tests/test_instance_creation.py
+++ b/tests/test_instance_creation.py
@@ -96,13 +96,6 @@ def test_resolves_instances_with_prototype_scope():
     expect(mw1).not_to(equal(mw2))
 
 
-def test_registering_instance_scope_without_an_instance_is_exception():
-    container = Container()
-
-    with pytest.raises(InvalidRegistrationException):
-        container.register(MessageWriter, StdoutMessageWriter, scope=Scope.instance)
-
-
 def test_registering_an_instance_as_concrete_is_exception():
     """
     Concrete registrations need to be a constructable type

--- a/tests/test_instance_creation.py
+++ b/tests/test_instance_creation.py
@@ -66,9 +66,9 @@ def test_can_register_an_instance():
     expect(container.resolve(MessageWriter)).to(equal(writer))
 
 
-def test_resolves_instances_with_default_scope():
+def test_resolves_instances():
     """
-    No scope specified should work the way prototype scope works
+    No scope specified should work the way transient scope works
     """
     container = Container()
     container.register(MessageWriter, StdoutMessageWriter)
@@ -89,28 +89,18 @@ def test_resolves_instances_with_singleton_scope():
 
 def test_resolves_instances_with_prototype_scope():
     container = Container()
-    container.register(MessageWriter, StdoutMessageWriter, scope=Scope.prototype)
+    container.register(MessageWriter, StdoutMessageWriter, scope=Scope.transient)
 
     mw1 = container.resolve(MessageWriter)
     mw2 = container.resolve(MessageWriter)
     expect(mw1).not_to(equal(mw2))
 
 
-def test_resolves_instances_with_default_singleton():
-    container = Container(default_scope=Scope.singleton)
-    container.register(MessageWriter, StdoutMessageWriter)
-
-    mw1 = container.resolve(MessageWriter)
-    mw2 = container.resolve(MessageWriter)
-    expect(mw1).to(equal(mw2))
-
-
-def test_registering_an_instance_with_prototype_scope_is_exception():
+def test_registering_instance_scope_without_an_instance_is_exception():
     container = Container()
-    writer = StdoutMessageWriter()
 
     with pytest.raises(InvalidRegistrationException):
-        container.register(MessageWriter, instance=writer, scope=Scope.prototype)
+        container.register(MessageWriter, StdoutMessageWriter, scope=Scope.instance)
 
 
 def test_registering_an_instance_as_concrete_is_exception():


### PR DESCRIPTION
I'd appreciate any feedback on the implementation method - its a bit hacky but seems to work fine. In short if a Registration is flagged as singleton, the first time it is resolved it is "promoted" to an instance scope. The required changing Registration from a NamedTuple to a dataclass.

I'm open to feedback and alternate implementations. As is, this shouldn't change the external API if you don't need this functionality.