### PR TITLE
Rework of annotation behavior

### DIFF
--- a/punq/__init__.py
+++ b/punq/__init__.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 
 from pkg_resources import DistributionNotFound, get_distribution
 
-from ._compat import is_generic_list, ensure_forward_ref
+from ._compat import is_generic_list, ensure_forward_ref, get_globals_and_locals_of_parent
 
 try:  # pragma no cover
     __version__ = get_distribution(__name__).version
@@ -174,8 +174,7 @@ class Registry:
             try:
                 service = get_type_hints(
                     SimpleNamespace(__annotations__={"service": service}),
-                    frame.f_globals,
-                    frame.f_locals,
+                    *get_globals_and_locals_of_parent(frame),
                 )["service"]
             except NameError:
                 pass
@@ -313,7 +312,7 @@ class Container:
             Sending message via smtp
         """
 
-        frame = sys._getframe(1)  # There MUST be a better way!
+        frame = inspect.currentframe()
 
         self.registrations.register(service, frame, factory, instance, scope, **kwargs)
         return self

--- a/punq/__init__.py
+++ b/punq/__init__.py
@@ -160,13 +160,23 @@ class Registry:
         return existing
 
     def register(
-        self, service, frame, factory=empty, instance=empty, scope=Scope.transient, **kwargs
+        self,
+        service,
+        frame,
+        factory=empty,
+        instance=empty,
+        scope=Scope.transient,
+        **kwargs,
     ):
         resolve_args = kwargs or {}
 
         if isinstance(service, str):
             try:
-                service = get_type_hints(SimpleNamespace(__annotations__={"service": service}), frame.f_globals, frame.f_locals)["service"]
+                service = get_type_hints(
+                    SimpleNamespace(__annotations__={"service": service}),
+                    frame.f_globals,
+                    frame.f_locals,
+                )["service"]
             except NameError:
                 pass
 

--- a/punq/__init__.py
+++ b/punq/__init__.py
@@ -7,7 +7,11 @@ from types import SimpleNamespace
 
 from pkg_resources import DistributionNotFound, get_distribution
 
-from ._compat import is_generic_list, ensure_forward_ref, get_globals_and_locals_of_parent
+from ._compat import (
+    is_generic_list,
+    ensure_forward_ref,
+    get_globals_and_locals_of_parent,
+)
 
 try:  # pragma no cover
     __version__ = get_distribution(__name__).version
@@ -312,7 +316,9 @@ class Container:
             Sending message via smtp
         """
 
-        self.registrations.register(service, inspect.currentframe(), factory, instance, scope, **kwargs)
+        self.registrations.register(
+            service, inspect.currentframe(), factory, instance, scope, **kwargs
+        )
         return self
 
     def resolve_all(self, service, **kwargs):

--- a/punq/__init__.py
+++ b/punq/__init__.py
@@ -312,9 +312,7 @@ class Container:
             Sending message via smtp
         """
 
-        frame = inspect.currentframe()
-
-        self.registrations.register(service, frame, factory, instance, scope, **kwargs)
+        self.registrations.register(service, inspect.currentframe(), factory, instance, scope, **kwargs)
         return self
 
     def resolve_all(self, service, **kwargs):

--- a/punq/_compat.py
+++ b/punq/_compat.py
@@ -20,3 +20,11 @@ def is_generic_list(service):
 def ensure_forward_ref(self, service, frame, factory, instance, **kwargs):
     if isinstance(service, str):
         self.register(ForwardRef(service), frame, factory, instance, **kwargs)
+
+
+def get_globals_and_locals_of_parent(maybe_frame):
+    try:
+        parent_frame = maybe_frame.f_back
+    except AttributeError:
+        return {}, {}
+    return parent_frame.f_globals, parent_frame.f_locals

--- a/punq/_compat.py
+++ b/punq/_compat.py
@@ -17,6 +17,6 @@ def is_generic_list(service):
         return False
 
 
-def ensure_forward_ref(self, service, factory, instance, **kwargs):
+def ensure_forward_ref(self, service, frame, factory, instance, **kwargs):
     if isinstance(service, str):
-        self.register(ForwardRef(service), factory, instance, **kwargs)
+        self.register(ForwardRef(service), frame, factory, instance, **kwargs)

--- a/tests/conflicts/conflicting.py
+++ b/tests/conflicts/conflicting.py
@@ -1,0 +1,6 @@
+import attr
+
+
+@attr.s
+class SameName:
+    pass

--- a/tests/conflicts/str_annotations.py
+++ b/tests/conflicts/str_annotations.py
@@ -1,16 +1,15 @@
-from __future__ import annotations
-
 import attr
 
 
-@attr.dataclass
+@attr.s
 class SameName:
     pass
 
 
 @attr.dataclass
 class Consumer:
-    attribute: SameName
+    # Emulate "from __future__ import annotations"
+    attribute: "SameName"
 
     def is_valid(self):
         return isinstance(self.attribute, SameName)

--- a/tests/conflicts/str_annotations.py
+++ b/tests/conflicts/str_annotations.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import attr
+
+
+@attr.dataclass
+class SameName:
+    pass
+
+
+@attr.dataclass
+class Consumer:
+    attribute: SameName
+
+    def is_valid(self):
+        return isinstance(self.attribute, SameName)

--- a/tests/conflicts/type_annotations.py
+++ b/tests/conflicts/type_annotations.py
@@ -1,0 +1,14 @@
+import attr
+
+
+@attr.dataclass
+class SameName:
+    pass
+
+
+@attr.dataclass
+class Consumer:
+    attribute: SameName
+
+    def is_valid(self):
+        return isinstance(self.attribute, SameName)

--- a/tests/conflicts/type_annotations.py
+++ b/tests/conflicts/type_annotations.py
@@ -1,7 +1,7 @@
 import attr
 
 
-@attr.dataclass
+@attr.s
 class SameName:
     pass
 

--- a/tests/test_name_conflicts.py
+++ b/tests/test_name_conflicts.py
@@ -1,0 +1,30 @@
+"""
+These tests demonstrate an issue mentioned in
+https://github.com/bobthemighty/punq/issues/28
+"""
+
+import pytest
+
+import punq
+
+from tests.conflicts import conflicting
+from tests.conflicts import str_annotations
+from tests.conflicts import type_annotations
+
+
+@pytest.mark.parametrize("module", [str_annotations, type_annotations])
+def test_no_conflict(module):
+    container = punq.Container()
+    container.register(conflicting.SameName)
+    container.register(module.SameName)
+    container.register(module.Consumer)
+    assert container.resolve(module.Consumer).is_valid()
+
+
+@pytest.mark.parametrize("module", [str_annotations, type_annotations])
+def test_conflict(module):
+    container = punq.Container()
+    container.register(module.SameName)
+    container.register(conflicting.SameName)
+    container.register(module.Consumer)
+    assert container.resolve(module.Consumer).is_valid()

--- a/tests/test_name_conflicts.py
+++ b/tests/test_name_conflicts.py
@@ -7,6 +7,8 @@ import pytest
 
 import punq
 
+from expects import expect, be_true
+
 from tests.conflicts import conflicting
 from tests.conflicts import str_annotations
 from tests.conflicts import type_annotations
@@ -18,7 +20,7 @@ def test_no_conflict(module):
     container.register(conflicting.SameName)
     container.register(module.SameName)
     container.register(module.Consumer)
-    assert container.resolve(module.Consumer).is_valid()
+    expect(container.resolve(module.Consumer).is_valid()).to(be_true)
 
 
 @pytest.mark.parametrize("module", [str_annotations, type_annotations])
@@ -27,4 +29,4 @@ def test_conflict(module):
     container.register(module.SameName)
     container.register(conflicting.SameName)
     container.register(module.Consumer)
-    assert container.resolve(module.Consumer).is_valid()
+    expect(container.resolve(module.Consumer).is_valid()).to(be_true)

--- a/tests/test_string_annotations.py
+++ b/tests/test_string_annotations.py
@@ -41,17 +41,6 @@ def test_can_resolve_objects_with_forward_references():
     assert instance.dep.val == 1
 
 
-def test_forward_references_must_be_registered_before_their_clients():
-    """
-    If we haven't registered the 'Dependency' type yet, then we'll raise
-    a specific error so people can at least work out what the hell is happening
-    """
-    container = punq.Container()
-
-    with pytest.raises(punq.InvalidForwardReferenceException):
-        container.register(Client)
-
-
 def test_forward_references_can_be_registered_as_strings():
     """
     For cases where you want to declare a ref like 'module.Dep' we allow you to


### PR DESCRIPTION
This PR adds a test reproducing the scenario outlined in #28. It also implements a fix to the issue, but introduces a variety of behavioral differences that may present issues.

Changes:
- Type hints are now resolved relative to the class definition, not an abstract local namespace. As such, the InvalidForwardReference behavior has been dropped. (I'll be honest, when I hit the exception, it *really* messed up my mental model of how punq works.)
- Attendant to the above, the _localns member no longer exists.
- Registration now resolves types relative to the call site on supported interpreters (including CPython, pypy, and apparently Stackless?)