### PR TITLE
Add instantiate() function and tests

### DIFF
--- a/punq/__init__.py
+++ b/punq/__init__.py
@@ -465,3 +465,15 @@ class Container:
         context = self.registrations.build_context(service_key)
 
         return self._resolve_impl(service_key, kwargs, context)
+
+    def instantiate(self, service_key, **kwargs):
+        """
+        Instantiate an unregistered service
+        """
+        registration = Registration(
+            service_key, Scope.transient, service_key,
+            self.registrations._get_needs_for_ctor(service_key), {})
+
+        context = ResolutionContext(service_key, list([registration]))
+
+        return self._build_impl(registration, kwargs, context)

--- a/tests/test_instance_creation.py
+++ b/tests/test_instance_creation.py
@@ -201,6 +201,34 @@ def test_resolve_all_returns_all_registrations_in_order():
     expect(second).to(be_a(TmpFileMessageWriter))
 
 
+def test_can_instatiate_with_no_dependencies():
+    container = Container()
+
+    expect(container.instantiate(StdoutMessageWriter)).to(be_a(StdoutMessageWriter))
+
+
+def test_instantiate_dependencies_are_injected():
+    container = Container()
+    container.register(MessageWriter, StdoutMessageWriter)
+    container.register(MessageSpeaker)
+
+    speaker = container.instantiate(HelloWorldSpeaker)
+
+    expect(speaker).to(be_a(HelloWorldSpeaker))
+    expect(speaker.writer).to(be_a(StdoutMessageWriter))
+
+
+def test_can_instantiate_with_a_custom_factory():
+    container = Container()
+    container.register(MessageWriter, lambda: "win")
+    container.register(MessageSpeaker)
+
+    speaker = container.instantiate(HelloWorldSpeaker)
+
+    expect(speaker).to(be_a(HelloWorldSpeaker))
+    expect(speaker.writer).to(equal("win"))
+
+
 def test_can_use_a_string_key():
     container = Container()
     container.register("foo", instance=1)


### PR DESCRIPTION
Sometimes we want to instantiate a class using dependencies in the container, but we do not need to register the class itself to the container. Currently this looks like:
```
container.register(Class)
instance = container.resolve(Class)
```
Adding the instantiate function would allow us to use
```
instance = container.instantiate(Class)
```
and therefore not add Class to the container.

Any/All feedback is apprecaited! 