### PR TITLE
fix: Bug introduced by special case in resolve for lists 

### DIFF
--- a/punq/__init__.py
+++ b/punq/__init__.py
@@ -510,9 +510,6 @@ class Container:
 
         target = context.target(service_key)
 
-        if target.is_generic_list():
-            return self.resolve_all(target.generic_parameter)
-
         registration = target.next_impl()
 
         if registration is None and default is not None:

--- a/tests/test_annotated_types.py
+++ b/tests/test_annotated_types.py
@@ -1,0 +1,53 @@
+from enum import Enum
+from typing import Annotated, Generic, Type, TypeVar
+
+import punq
+from punq import PunqAnnotation
+
+container = punq.Container()
+
+class Topics(Enum):
+    distance = '/distance'
+
+T = TypeVar('T')
+
+class Subscriber(Generic[T]):
+    def __init__(self, msg_type: Type[T], topic: str):
+        self.msg_type = msg_type
+        self.topic = topic
+
+class Test:
+    def __init__(
+        self,
+        temp_sub: Annotated[Subscriber[float], PunqAnnotation, '/topic/temp'],
+        dist_sub: Annotated[Subscriber[float], PunqAnnotation, Topics.distance],
+        param1: Annotated[int, 'an annotation that is not for punq'],
+        param2: int
+    ):
+        self.temp_sub: Subscriber[float] = temp_sub
+        self.dist_sub: Subscriber[float] = dist_sub
+        self.param1 = param1
+        self.param2 = param2
+
+
+def test_annotated_types():
+    temp_sub = Subscriber(float, '/topic/temp')
+    container.register(Annotated[Subscriber[float], PunqAnnotation, '/topic/temp'], instance=temp_sub)
+
+    dist_sub = Subscriber(float, '/topic/dist')
+    container.register(Annotated[Subscriber[float], PunqAnnotation, Topics.distance], instance=dist_sub)
+
+    container.register(int, instance=88)
+
+    container.register(Test)
+    test: Test = container.resolve(Test)
+
+    assert test.temp_sub.topic == '/topic/temp'
+
+    assert test.dist_sub.topic == '/topic/dist'
+    assert test.param1 == 88
+    assert test.param2 == 88
+
+
+
+test_annotated_types()


### PR DESCRIPTION
Before this PR the following code 
```
from typing import List

import punq

container = punq.Container()

container.register(List[str], instance=['hi'])
print(container.resolve(List[str]))
print(container.resolve(List[str]))
print(container.resolve_all(List[str]))
print(container.resolve(List[str]))
```
would result in 
```
[]
[]
[['hi']]
['hi']
```

Resolve should resolve the `List[str]` in the first two resolve calls. Further be idempotent, as long as nothing nothing new is registered and the `resolve_all` call should not effect the result of subsequent calls to `resolve`.


After this PR the result is: 
```
['hi']
['hi']
[['hi']]
['hi']
```