### PR TITLE
Remove useless line

### DIFF
--- a/punq/__init__.py
+++ b/punq/__init__.py
@@ -148,9 +148,6 @@ class _Registration(NamedTuple):
     needs: Any
     args: list[Any]
 
-    def __str__(self):
-        return f"Registration <{self.service}>"
-
 
 class _Empty:
     pass
@@ -314,9 +311,6 @@ class _ResolutionTarget:
     def next_impl(self):
         if len(self.impls) > 0:
             return self.impls.pop()
-
-    def __str__(self):
-        return f"ResolutionTarget {self.service}, (impls: {self.impls})"
 
 
 class _ResolutionContext:

--- a/punq/__init__.py
+++ b/punq/__init__.py
@@ -315,6 +315,7 @@ class _ResolutionTarget:
     def __str__(self):
         return f"ResolutionTarget({self.service}, {self.impls})"
 
+
 class _ResolutionContext:
     def __init__(self, key, impls):
         self.targets = {key: _ResolutionTarget(key, impls)}
@@ -486,13 +487,11 @@ class Container:
             return context[service_key]
 
         target = context.target(service_key)
-        print(target)
 
         if target.is_generic_list():
             return self.resolve_all(target.generic_parameter)
 
         registration = target.next_impl()
-        print(registration)
 
         if registration is None and default is not None:
             return default

--- a/punq/__init__.py
+++ b/punq/__init__.py
@@ -148,6 +148,9 @@ class _Registration(NamedTuple):
     needs: Any
     args: list[Any]
 
+    def __str__(self):
+        return f"Registration <{self.service}>"
+
 
 class _Empty:
     pass
@@ -311,6 +314,9 @@ class _ResolutionTarget:
     def next_impl(self):
         if len(self.impls) > 0:
             return self.impls.pop()
+
+    def __str__(self):
+        return f"ResolutionTarget {self.service}, (impls: {self.impls})"
 
 
 class _ResolutionContext:
@@ -495,9 +501,6 @@ class Container:
 
         if registration is None:
             raise MissingDependencyError("Failed to resolve implementation for " + str(service_key))
-
-        if service_key in registration.needs.values():
-            self._resolve_impl(service_key, kwargs, context)
 
         return self._build_impl(registration, kwargs, context)
 

--- a/punq/__init__.py
+++ b/punq/__init__.py
@@ -312,9 +312,6 @@ class _ResolutionTarget:
         if len(self.impls) > 0:
             return self.impls.pop()
 
-    def __str__(self):
-        return f"ResolutionTarget({self.service}, {self.impls})"
-
 
 class _ResolutionContext:
     def __init__(self, key, impls):

--- a/punq/__init__.py
+++ b/punq/__init__.py
@@ -312,6 +312,8 @@ class _ResolutionTarget:
         if len(self.impls) > 0:
             return self.impls.pop()
 
+    def __str__(self):
+        return f"ResolutionTarget({self.service}, {self.impls})"
 
 class _ResolutionContext:
     def __init__(self, key, impls):
@@ -484,11 +486,13 @@ class Container:
             return context[service_key]
 
         target = context.target(service_key)
+        print(target)
 
         if target.is_generic_list():
             return self.resolve_all(target.generic_parameter)
 
         registration = target.next_impl()
+        print(registration)
 
         if registration is None and default is not None:
             return default

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -6,9 +6,11 @@ import punq
 class SomeVeryHeavyDep:
     pass
 
+
 class SubSystemA:
     def __init__(self, d: SomeVeryHeavyDep):
         self.dep = d
+
 
 class SubSystemB:
     def __init__(self, d: SomeVeryHeavyDep):
@@ -19,6 +21,7 @@ class Root:
     def __init__(self, a: SubSystemA, b: SubSystemB):
         self.a = a
         self.b = b
+
 
 def test_that_repeated_resolutions_are_cached():
     """

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+import punq
+
+
+class SomeVeryHeavyDep:
+    pass
+
+class SubSystemA:
+    def __init__(self, d: SomeVeryHeavyDep):
+        self.dep = d
+
+class SubSystemB:
+    def __init__(self, d: SomeVeryHeavyDep):
+        self.dep = d
+
+
+class Root:
+    def __init__(self, a: SubSystemA, b: SubSystemB):
+        self.a = a
+        self.b = b
+
+def test_that_repeated_resolutions_are_cached():
+    """
+    In this test we have two dependencies, each of which
+    depends in turn on SomeVeryHeavyDep.
+
+    We should use the same instance of SomeVeryHeavyDep
+    for both resolutions, even though it is registered
+    as transient.
+    """
+    container = punq.Container()
+
+    container.register(SomeVeryHeavyDep, scope=punq.Scope.transient)
+    container.register(SubSystemA)
+    container.register(SubSystemB)
+    container.register(Root)
+
+    instance = container.resolve(Root)
+
+    assert instance.a.dep is instance.b.dep


### PR DESCRIPTION
I think this line of code was intended to support the recursive resolution case in test_chain_dependencies, ie, if the service depends on itself, then recursively resolve it, putting things in the context as you go.

It's not necessary, though, since _build_impl already handles that.

This fixes #169